### PR TITLE
適切な環境へgemを再振分、mysql用にdocker-compose.ymlファイルを作成し設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,30 +13,24 @@ gem 'coffee-rails', '~> 4.2'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
-
 gem 'active_model_serializers'
 gem 'devise_token_auth'
-gem 'rubocop-rails'
-gem 'rubocop-rspec'
-gem 'annotate'
-gem 'pry-byebug'
-gem 'pry-rails'
-gem 'pry-doc'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'rubocop-rails'
+  gem 'rubocop-rspec'
+  gem 'pry-byebug'
+  gem 'pry-rails'
+  gem 'pry-doc'
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'annotate'
 end
 
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+
+services:
+  database:
+    restart: always
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-datavolume:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
+volumes:
+  mysql-datavolume:
+    driver: local


### PR DESCRIPTION
Task4で指摘いただいた通り、gemファイルを環境ごとに振り分けました。
また、dockerでmysqlを導入するため、docker-compose.ymlファイルに以下内容記載しています（ToR level1、`データベースの環境構築 by Docker`と同じ内容）。

```:docker-compose.yml
version: '3.2'

services:
  database:
    restart: always
    image: mysql:latest
    ports:
      - 3306:3306
    command: --default-authentication-plugin=mysql_native_password
    volumes:
      - mysql-datavolume:/var/lib/mysql
    environment:
      MYSQL_ROOT_PASSWORD: root

volumes:
  mysql-datavolume:
    driver: local
```
【気になった点】
ToR level1にてdockerによるmysqlを導入していた影響で、`docker-compose up -d`を実行した際に、既にポートを使用しているという以下エラーが発生しました。
```
ERROR: for qiita_clone_database_1  Cannot start service database: driver failed programming external connectivity on endpoint qiita_clone_database_1 (7c6a9f093e93f74360cf2c911ec6ff721a26a315f1d7a10794ed184a44613c54): Bind for 0.0.0.0:3306 failed: port is already allocated

ERROR: for database  Cannot start service database: driver failed programming external connectivity on endpoint qiita_clone_database_1 (7c6a9f093e93f74360cf2c911ec6ff721a26a315f1d7a10794ed184a44613c54): Bind for 0.0.0.0:3306 failed: port is already allocated
ERROR: Encountered errors while bringing up the project.
```
https://coinbaby8.com/docker-beginner.html#Docker_port
を参考に対処しましたが、dockerアプリの終了を求められるなど、mysqlの起動がうまくできませんでした。その後dockerのアプリ（GUI）にてlevel1で使用したコンテナの停止、当qiitaアプリで使用するコンテナを起動するとスムーズにmysqlを起動することができました。
